### PR TITLE
fix: multi definition issues

### DIFF
--- a/include/pasta/utils/debug_asserts.hpp
+++ b/include/pasta/utils/debug_asserts.hpp
@@ -48,12 +48,12 @@ namespace pasta {
  * \param location Source location of the assertion, default parameter.
  */
 #ifdef has_source_location
-void pasta_assert_impl(
+static void pasta_assert_impl(
     bool const condition,
     std::string_view const message,
     std::source_location const location = std::source_location::current()) {
 #else
-void pasta_assert_impl(bool const condition, std::string_view const message) {
+static void pasta_assert_impl(bool const condition, std::string_view const message) {
 #endif
   if (!condition) {
 #ifdef has_source_location


### PR DESCRIPTION
I head an issue, when using pasta-toolbox/bitvector and it traceback to the utils.

When including (directly or indirectly) debug_asserts.hpp in two different translation units (cpp-files), than each will create a definition of the function `pasta_assert_impl`, which causes a multi definition error of that function when linking. To solve this, we must either mark it with 'static' or 'inline'. There a different advantages to either.
I decided to go with 'static' which means, that when translating the function for a translation unit, do not make the symbols available for any other files.